### PR TITLE
Default to all tone selection

### DIFF
--- a/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
@@ -126,7 +126,7 @@ abstract public class BaseDriveModeActivity extends Activity {
                 prefs.getInt(getString(R.string.checkpoint_frequency_key),
                         Constants.DEFAULT_CHECKPOINT_FREQUENCY_SECONDS) * 1000;
         availableAlarmTones =
-                new ArrayList<String>(prefs.getStringSet(getString(R.string.alarm_tones_key), new HashSet()));
+                new ArrayList<String>(prefs.getStringSet(getString(R.string.alarm_tones_key), Constants.allAlarmTones));
         int alertModeCode = prefs.getInt(getString(R.string.alert_style_key),
                 Constants.DEFAULT_ALERT_STYLE.getCode());
         alertMode = Constants.AlertMode.fromCode(alertModeCode);

--- a/app/src/main/java/com/knottycode/drivesafe/Constants.java
+++ b/app/src/main/java/com/knottycode/drivesafe/Constants.java
@@ -2,6 +2,9 @@ package com.knottycode.drivesafe;
 
 import android.content.Context;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Created by thammaknot on 1/21/17.
  */
@@ -18,6 +21,18 @@ public class Constants {
     public static final String RECORDED_TONE_FILENAME = "recorded_tone.3gp";
     public static final float ALERT_VOLUME = 0.8f;
     public static final String ALARM_PATH_PREFIX = "alarm";
+
+    public static final Set<String> allAlarmTones = new HashSet<String>();
+
+    static {
+        allAlarmTones.add("best_wake_up_sound.mp3");
+        allAlarmTones.add("car_alarm.mp3");
+        allAlarmTones.add("emergency_alert.mp3");
+        allAlarmTones.add("fore_truck_siren.mp3");
+        allAlarmTones.add("funny_alarm.mp3");
+        allAlarmTones.add("pager_tone_112.mp3");
+        allAlarmTones.add("rooster_alarm.mp3");
+    }
 
     public static final long[] VIBRATION_PATTERN = {0, 700, 100, 400};
 

--- a/app/src/main/java/com/knottycode/drivesafe/Constants.java
+++ b/app/src/main/java/com/knottycode/drivesafe/Constants.java
@@ -15,7 +15,7 @@ public class Constants {
     public static final int TIMER_INTERVAL_MILLIS = 100;
     public static final int CHECKPOINT_GRACE_PERIOD_MILLIS = 5 * 1000;
     public static final int DEFAULT_CHECKPOINT_FREQUENCY_SECONDS = 10;
-    public static final AlertMode DEFAULT_ALERT_STYLE = AlertMode.SCREEN;
+    public static final AlertMode DEFAULT_ALERT_STYLE = AlertMode.SOUND;
 
     public static final String DEFAULT_ALERT_SOUND = "alert/glitchy-tone.mp3";
     public static final String RECORDED_TONE_FILENAME = "recorded_tone.3gp";

--- a/app/src/main/java/com/knottycode/drivesafe/MainActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/MainActivity.java
@@ -55,7 +55,8 @@ public class MainActivity extends Activity {
                 prefs.getInt(getString(R.string.checkpoint_frequency_key),
                         Constants.DEFAULT_CHECKPOINT_FREQUENCY_SECONDS) * 1000;
         availableAlarmTones =
-                new ArrayList<String>(prefs.getStringSet(getString(R.string.alarm_tones_key), new HashSet()));
+                new ArrayList<String>(prefs.getStringSet(getString(R.string.alarm_tones_key),
+                        Constants.allAlarmTones));
         int alertModeCode = prefs.getInt(getString(R.string.alert_style_key),
                 Constants.DEFAULT_ALERT_STYLE.getCode());
         alertMode = Constants.AlertMode.fromCode(alertModeCode);

--- a/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
@@ -217,7 +217,7 @@ public class SettingsActivity extends AppCompatActivity implements View.OnTouchL
         TextView alertStyleTextView = (TextView) findViewById(R.id.alertStyleValue);
         Constants.AlertMode mode =
                 Constants.AlertMode.fromCode(prefs.getInt("alert_style",
-                        Constants.AlertMode.SOUND.getCode()));
+                        Constants.DEFAULT_ALERT_STYLE.getCode()));
         alertStyleTextView.setText(mode.getDisplayString(this));
 
         TextView alarmTonesValueTextView = (TextView) findViewById(R.id.alarmTonesValue);

--- a/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
@@ -399,7 +399,8 @@ public class SettingsActivity extends AppCompatActivity implements View.OnTouchL
                                 } else if (selected.contains(tone)) {
                                     if (selected.size() == 1) {
                                         selectedBoolean[which] = true;
-                                        Toast.makeText(SettingsActivity.this, "Cannot deselect", Toast.LENGTH_SHORT).show();
+                                        Toast.makeText(SettingsActivity.this, R.string.zero_tone_warning,
+                                                Toast.LENGTH_SHORT).show();
                                     } else {
                                         // Else, if the item is already in the array, remove it
                                         selected.remove(tone);

--- a/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/SettingsActivity.java
@@ -18,6 +18,7 @@ import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 import android.widget.Switch;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -221,7 +222,7 @@ public class SettingsActivity extends AppCompatActivity implements View.OnTouchL
 
         TextView alarmTonesValueTextView = (TextView) findViewById(R.id.alarmTonesValue);
         Set<String> savedTones = prefs.getStringSet(getString(R.string.alarm_tones_key),
-                new HashSet<String>());
+                Constants.allAlarmTones);
         alarmTonesValueTextView.setText(getSelectedTonesMessage(savedTones.size()));
 
     }
@@ -396,8 +397,13 @@ public class SettingsActivity extends AppCompatActivity implements View.OnTouchL
                                     selected.add(tone);
                                     playTone(tone);
                                 } else if (selected.contains(tone)) {
-                                    // Else, if the item is already in the array, remove it
-                                    selected.remove(tone);
+                                    if (selected.size() == 1) {
+                                        selectedBoolean[which] = true;
+                                        Toast.makeText(SettingsActivity.this, "Cannot deselect", Toast.LENGTH_SHORT).show();
+                                    } else {
+                                        // Else, if the item is already in the array, remove it
+                                        selected.remove(tone);
+                                    }
                                     resetMediaPlayer();
                                 }
                             }

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -34,6 +34,7 @@
 
     <string name="ok">ตกลง</string>
     <string name="cancel">ยกเลิก</string>
+    <string name="cannot_deselect">ต้องเลือกอย่างน้อย 1 เสียง</string>
 
     <string name="tone_best_wake_up_sound">ตื่นๆๆ</string>
     <string name="tone_car_alarm">กันขโมยรถ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
 
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
+    <string name="zero_tone_warning">Must select at least one tone</string>
 
     <string name="tone_best_wake_up_sound">Wake Me Up</string>
     <string name="tone_car_alarm">Car Alarm</string>


### PR DESCRIPTION
If no tones is saved, default to selecting all tones (both in Settings, Main, and Driving Activities).
Also, in the tone selection dialog, if the last tone is deselected, show a toast and overwrite that deselection.