### PR TITLE
Continuous ASR

### DIFF
--- a/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
+++ b/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
@@ -1,5 +1,6 @@
 package com.knottycode.drivesafe;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.speech.RecognitionListener;
 import android.speech.SpeechRecognizer;
@@ -15,14 +16,19 @@ public class ASRListener implements RecognitionListener {
 
     private List<String> results;
     private BaseDriveModeActivity activity;
+    private boolean asrActive = false;
     private boolean isListening = false;
+    // Whether to continue listening for ASR.
+    private boolean continuousAsr = true;
+    private SpeechRecognizer recognizer;
+    private Intent intent;
 
     public ASRListener(BaseDriveModeActivity activity) {
         this.activity = activity;
     }
 
     public void onResults(Bundle bundle) {
-        Log.d(TAG, "onResults " + bundle);
+        Log.d(TAG, "onResults inside ASR Listener");
         results = bundle.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
         for (int i = 0; i < results.size(); i++)
         {
@@ -50,6 +56,10 @@ public class ASRListener implements RecognitionListener {
 
     public void onError(int error) {
         Log.d(TAG,  "error " +  error);
+        if (error == SpeechRecognizer.ERROR_NO_MATCH) {
+            // Possibly empty input audio, restart ASR.
+            startRecognition();
+        }
     }
 
     public void onPartialResults(Bundle partialResults) {
@@ -62,5 +72,28 @@ public class ASRListener implements RecognitionListener {
 
     public boolean isListening() {
         return isListening;
+    }
+
+    public void setRecognizer(SpeechRecognizer recognizer, Intent intent) {
+        this.recognizer = recognizer;
+        this.intent = intent;
+    }
+
+    public void startRecognition() {
+        if (asrActive) {
+            recognizer.stopListening();
+        }
+        asrActive = true;
+        recognizer.startListening(intent);
+    }
+
+    public void stopRecognition() {
+        asrActive = false;
+        recognizer.stopListening();
+        recognizer.cancel();
+    }
+
+    public boolean isAsrActive() {
+        return asrActive;
     }
 }

--- a/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
@@ -11,6 +11,7 @@ import android.media.MediaPlayer;
 import android.os.Handler;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
+import android.util.Log;
 import android.view.Window;
 import android.view.WindowManager;
 
@@ -84,9 +85,8 @@ abstract public class BaseDriveModeActivity extends Activity {
     public void onPause() {
         audioManager.setStreamVolume(ALARM_STREAM, initialVolume, 0);
         if (recognizer != null) {
-            activeASR = false;
-            recognizer.stopListening();
-            recognizer.destroy();
+            Log.d(TAG, "ASR Listener:: calling stopRecognition from onPause");
+            asrListener.stopRecognition();
         }
         super.onPause();
     }
@@ -140,8 +140,10 @@ abstract public class BaseDriveModeActivity extends Activity {
                 this.getPackageName());
         recognizer = SpeechRecognizer.createSpeechRecognizer(this);
         recognizer.setRecognitionListener(asrListener);
+        asrListener.setRecognizer(recognizer, intent);
         activeASR = true;
-        recognizer.startListening(intent);
+        // recognizer.startListening(intent);
+        asrListener.startRecognition();
     }
 
     /**
@@ -154,9 +156,10 @@ abstract public class BaseDriveModeActivity extends Activity {
         if (percent < 0.5) {
             if (adaptiveLoudness) {
                 audioManager.setStreamVolume(ALARM_STREAM, (int) Math.ceil(maxVolume / 2.0), 0);
-            } else {
-                audioManager.setStreamVolume(ALARM_STREAM, maxVolume, 0);
             }
+        }
+        if (!adaptiveLoudness) {
+            audioManager.setStreamVolume(ALARM_STREAM, maxVolume, 0);
         }
     }
 

--- a/app/src/main/java/com/knottycode/drivesafe/Constants.java
+++ b/app/src/main/java/com/knottycode/drivesafe/Constants.java
@@ -14,7 +14,8 @@ public class Constants {
 
     public static final int TIMER_INTERVAL_MILLIS = 100;
     public static final int CHECKPOINT_GRACE_PERIOD_MILLIS = 5 * 1000;
-    public static final int QUESTION_ANSWER_GRACE_PERIOD_MILLIS = 5 * 1000;
+    public static final int QUESTION_ANSWER_GRACE_PERIOD_MILLIS = 15 * 1000;
+    public static final int MIN_TIME_TO_RESTART_ASR_MILLIS = 4 * 1000;
     public static final int DEFAULT_CHECKPOINT_FREQUENCY_SECONDS = 10;
     public static final AlertMode DEFAULT_ALERT_STYLE = AlertMode.SOUND;
     public static final int UNIT_SILENCE_DURATION_MILLIS = 500;
@@ -42,9 +43,11 @@ public class Constants {
     public static final String ANSWER_UTT_ID = "00000002";
     public static final String SILENCE_UTT_ID = "00000003";
     public static final String CORRECT_KEYWORD_UTT_ID = "00000004";
+    public static final String TRY_AGAIN_UTT_ID = "00000005";
 
     public static final String ANSWER_KEYWORD = "เฉลย";
     public static final String CORRECT_KEYWORD = "ถูกต้องนะค้า";
+    public static final String TRY_AGAIN_KEYWORD = "ลองอีกทีนะ";
     public static final Set<String> SKIP_WORDS = new HashSet<String>();
 
     static {


### PR DESCRIPTION
Constantly (re)starting ASR so that the app keeps listening to the user's input for the entirety of QAActivity.

This is achieved by intercepting calls to onError with ERROR_NO_MATCH (ie, signifying empty speech) and restarting ASR.

The app will keep restarting ASR as long as there's "enough" time remaining in the QA grace period. Otherwise, it will just go straight to revealing the answer.