### PR TITLE
Updated volume checking logic

### DIFF
--- a/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/BaseDriveModeActivity.java
@@ -80,7 +80,7 @@ abstract public class BaseDriveModeActivity extends Activity {
 
     @Override
     public void onPause() {
-        audioManager.setStreamVolume(ALARM_STREAM, initialVolume, 0);
+        // audioManager.setStreamVolume(ALARM_STREAM, initialVolume, 0);
         if (recognizer != null) {
             Log.d(TAG, "ASR Listener:: calling stopRecognition from onPause");
             asrListener.stopRecognition();
@@ -90,8 +90,8 @@ abstract public class BaseDriveModeActivity extends Activity {
 
     @Override
     public void onResume() {
-        initialVolume = audioManager.getStreamVolume(ALARM_STREAM);
-        validateSystemLoudness();
+        // initialVolume = audioManager.getStreamVolume(ALARM_STREAM);
+        // validateSystemLoudness();
         super.onResume();
     }
 
@@ -143,7 +143,10 @@ abstract public class BaseDriveModeActivity extends Activity {
     protected void validateSystemLoudness() {
         int volume = audioManager.getStreamVolume(ALARM_STREAM);
         int maxVolume = audioManager.getStreamMaxVolume(ALARM_STREAM);
-        audioManager.setStreamVolume(ALARM_STREAM, maxVolume, 0);
+        if (volume < maxVolume * 4 / 5) {
+            volume = maxVolume * 4 / 5;
+        }
+        audioManager.setStreamVolume(ALARM_STREAM, volume, 0);
     }
 
     protected void startAlarmMode() {

--- a/app/src/main/java/com/knottycode/drivesafe/CheckpointManager.java
+++ b/app/src/main/java/com/knottycode/drivesafe/CheckpointManager.java
@@ -28,6 +28,7 @@ public class CheckpointManager implements Serializable {
     private long driveModeStartTime = -1;
     private List<QuestionAnswer> questions;
     private int nextQuestionIndex = 0;
+    private boolean volumeAdjusted = false;
 
     private static final int MIN_FREQUENCY_MILLIS = 30 * 1000;
     private static final int MAX_FREQUENCY_MILLIS = 5 * 60 * 1000;
@@ -111,5 +112,13 @@ public class CheckpointManager implements Serializable {
     
     public long getNextFrequencyMillis() {
         return nextFrequencyMillis;
+    }
+
+    public void setVolumeAdjusted(boolean b) {
+        volumeAdjusted = b;
+    }
+
+    public boolean getVolumeAdjusted() {
+        return volumeAdjusted;
     }
 }

--- a/app/src/main/java/com/knottycode/drivesafe/DriveModeActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/DriveModeActivity.java
@@ -1,7 +1,6 @@
 package com.knottycode.drivesafe;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.RelativeLayout;
@@ -36,7 +35,6 @@ public class DriveModeActivity extends BaseDriveModeActivity {
         });
 
         checkpointCountdownTimer = (TextView) findViewById(R.id.checkpointCountdownTimer);
-        Log.d(TAG, "******** volume adjusted = " + checkpointManager.getVolumeAdjusted());
         if (!checkpointManager.getVolumeAdjusted()) {
             validateSystemLoudness();
             checkpointManager.setVolumeAdjusted(true);

--- a/app/src/main/java/com/knottycode/drivesafe/DriveModeActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/DriveModeActivity.java
@@ -1,6 +1,7 @@
 package com.knottycode.drivesafe;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.RelativeLayout;
@@ -35,6 +36,11 @@ public class DriveModeActivity extends BaseDriveModeActivity {
         });
 
         checkpointCountdownTimer = (TextView) findViewById(R.id.checkpointCountdownTimer);
+        Log.d(TAG, "******** volume adjusted = " + checkpointManager.getVolumeAdjusted());
+        if (!checkpointManager.getVolumeAdjusted()) {
+            validateSystemLoudness();
+            checkpointManager.setVolumeAdjusted(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
Upon each launch of drive mode, we check volume and set it to be at least 80% of max volume.
Then, we don't check or set volume automatically again unless the user exits and enters drive mode again.