### PR TITLE
Fix ASR listening issue

### DIFF
--- a/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
+++ b/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
@@ -31,6 +31,7 @@ public class ASRListener implements RecognitionListener {
     }
 
     public void onResults(Bundle bundle) {
+        asrListeningStartTime = -1;
         results = bundle.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
         FirebaseCrash.log("ASRListener: onResults size = " + results.size());
         for (int i = 0; i < results.size(); i++)
@@ -42,8 +43,8 @@ public class ASRListener implements RecognitionListener {
 
     public void onBeginningOfSpeech() {
         FirebaseCrash.log("ASRListener: onBeginningOfSpeech");
+        Log.d(TAG, "####################  onBeginning of speech");
         isListening = true;
-        asrListeningStartTime = System.currentTimeMillis();
     }
 
     public void onReadyForSpeech(Bundle params) {
@@ -63,7 +64,7 @@ public class ASRListener implements RecognitionListener {
 
     public void onError(int error) {
         FirebaseCrash.log("ASRListener: onError. Code = " + error);
-        Log.d(TAG,  "error " +  error);
+        Log.d(TAG,  "!!!!!!! error " +  error);
         if (error == SpeechRecognizer.ERROR_NO_MATCH ||
                 error == SpeechRecognizer.ERROR_SPEECH_TIMEOUT) {
             // Possibly empty input audio, restart ASR.
@@ -81,6 +82,7 @@ public class ASRListener implements RecognitionListener {
 
     public void forceStopListening() {
         FirebaseCrash.log("ASRListener: Forced stop listening called.");
+        Log.d(TAG, ">>>>>forceStopListening");
         if (!asrActive) {
             return;
         }
@@ -110,6 +112,7 @@ public class ASRListener implements RecognitionListener {
         }
         asrActive = true;
         FirebaseCrash.log("ASRListener: Start listening");
+        asrListeningStartTime = System.currentTimeMillis();
         recognizer.startListening(intent);
     }
 

--- a/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
+++ b/app/src/main/java/com/knottycode/drivesafe/ASRListener.java
@@ -31,7 +31,6 @@ public class ASRListener implements RecognitionListener {
     }
 
     public void onResults(Bundle bundle) {
-        Log.d(TAG, "onResults inside ASR Listener");
         results = bundle.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
         FirebaseCrash.log("ASRListener: onResults size = " + results.size());
         for (int i = 0; i < results.size(); i++)
@@ -49,12 +48,9 @@ public class ASRListener implements RecognitionListener {
 
     public void onReadyForSpeech(Bundle params) {
         FirebaseCrash.log("ASRListener: onReadyForSpeech");
-        Log.d(TAG, "onReadyForSpeech");
     }
 
-    public void onRmsChanged(float rmsdB) {
-        Log.d(TAG, ">>>> onRMSChanged: " + rmsdB);
-    }
+    public void onRmsChanged(float rmsdB) {}
 
     public void onBufferReceived(byte[] buffer) {
         FirebaseCrash.log("ASRListener: onBufferReceived");
@@ -81,12 +77,10 @@ public class ASRListener implements RecognitionListener {
 
     public void onEvent(int eventType, Bundle params) {
         FirebaseCrash.log("ASRListener: onEvent: " + eventType);
-        Log.d(TAG, "onEvent " + eventType);
     }
 
     public void forceStopListening() {
         FirebaseCrash.log("ASRListener: Forced stop listening called.");
-        Log.d(TAG, "### FORCED STOP: " + asrActive);
         if (!asrActive) {
             return;
         }

--- a/app/src/main/java/com/knottycode/drivesafe/Constants.java
+++ b/app/src/main/java/com/knottycode/drivesafe/Constants.java
@@ -19,13 +19,14 @@ public class Constants {
 
     public static final int TIMER_INTERVAL_MILLIS = 100;
     public static final int CHECKPOINT_GRACE_PERIOD_MILLIS = 5 * 1000;
-    public static final int QUESTION_ANSWER_GRACE_PERIOD_MILLIS = 20 * 1000;
-    public static final int QUESTION_ANSWER_MAX_GRACE_PERIOD_MILLIS = 25 * 1000;
+    public static final int QUESTION_ANSWER_GRACE_PERIOD_MILLIS = 25 * 1000;
+    public static final int QUESTION_ANSWER_MAX_GRACE_PERIOD_MILLIS = 30 * 1000;
     public static final int GRACE_PERIOD_EXTENSION_SECONDS = 20;
     public static final int MIN_TIME_TO_RESTART_ASR_MILLIS = 4 * 1000;
     public static final int DEFAULT_CHECKPOINT_FREQUENCY_SECONDS = 30;
     public static final AlertMode DEFAULT_ALERT_STYLE = AlertMode.SOUND;
     public static final int UNIT_SILENCE_DURATION_MILLIS = 500;
+    public static final int MAX_ASR_LISTENING_MILLIS = 6 * 1000;
     public static final Locale THAI_LOCALE = new Locale("th", "TH");
     public static final int MAX_ASR_RESULTS = 10;
 

--- a/app/src/main/java/com/knottycode/drivesafe/QuestionAnswerActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/QuestionAnswerActivity.java
@@ -225,13 +225,23 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
 
     @Override
     protected void updateDisplay(long now) {
-        if (answerPhaseStartTime == -1) { return; }
-        /*
-        TextView debugTime = (TextView) findViewById(R.id.debugTime);
-        long elapsed = (now - answerPhaseStartTime) / 1000;
-        long seconds = elapsed % 60;
-        debugTime.setText(String.format("00:%02d [%s]", seconds, asrListener.isListening() ? "listen" : "not listen"));
-        */
+        long asrStart = asrListener.getAsrListeningStartTime();
+        if (asrStart == -1) {
+            return;
+        }
+        long elapsed = (now - asrStart);
+        Log.d(TAG, "*************** asr start: " + asrStart + " [" + elapsed + " vs " + Constants.MAX_ASR_LISTENING_MILLIS + "]");
+        if (elapsed > Constants.MAX_ASR_LISTENING_MILLIS) {
+            Log.d(TAG, "  !!! calling force stop listening!");
+            asrListener.forceStopListening();
+        }
+    }
+
+    private boolean forcedStopASR = false;
+
+    private void forceStopASR() {
+        forcedStopASR = true;
+        asrListener.forceStopListening();
     }
 
     @Override
@@ -247,6 +257,7 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
                 checkpointManager.updateScore(ScoreMode.INCORRECT);
                 speakAnswer();
             } else {
+                // forceStopASR();
                 checkpointManager.updateScore(ScoreMode.NO_RESPONSE);
                 startAlarmMode();
             }
@@ -254,6 +265,7 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
         } else if (checkpointElapsed >= Constants.QUESTION_ANSWER_GRACE_PERIOD_MILLIS + extension) {
             if (asrListener.isListening()) {
                 delayedAnswer = true;
+                asrListener.forceStopListening();
                 return false;
             }
             if (!delayedAnswer) {
@@ -261,6 +273,7 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
                     checkpointManager.updateScore(ScoreMode.INCORRECT);
                     speakAnswer();
                 } else {
+                    // forceStopASR();
                     checkpointManager.updateScore(ScoreMode.NO_RESPONSE);
                     startAlarmMode();
                 }

--- a/app/src/main/java/com/knottycode/drivesafe/QuestionAnswerActivity.java
+++ b/app/src/main/java/com/knottycode/drivesafe/QuestionAnswerActivity.java
@@ -230,18 +230,9 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
             return;
         }
         long elapsed = (now - asrStart);
-        Log.d(TAG, "*************** asr start: " + asrStart + " [" + elapsed + " vs " + Constants.MAX_ASR_LISTENING_MILLIS + "]");
         if (elapsed > Constants.MAX_ASR_LISTENING_MILLIS) {
-            Log.d(TAG, "  !!! calling force stop listening!");
             asrListener.forceStopListening();
         }
-    }
-
-    private boolean forcedStopASR = false;
-
-    private void forceStopASR() {
-        forcedStopASR = true;
-        asrListener.forceStopListening();
     }
 
     @Override
@@ -257,7 +248,6 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
                 checkpointManager.updateScore(ScoreMode.INCORRECT);
                 speakAnswer();
             } else {
-                // forceStopASR();
                 checkpointManager.updateScore(ScoreMode.NO_RESPONSE);
                 startAlarmMode();
             }
@@ -273,7 +263,6 @@ public class QuestionAnswerActivity extends BaseDriveModeActivity {
                     checkpointManager.updateScore(ScoreMode.INCORRECT);
                     speakAnswer();
                 } else {
-                    // forceStopASR();
                     checkpointManager.updateScore(ScoreMode.NO_RESPONSE);
                     startAlarmMode();
                 }


### PR DESCRIPTION
On some devices, ASR won't recognize voice at all.
One possible cause: mic detects some low-level noise and prevents ASR from determining the end of speech.

Solution:
- force stopping ASR (stopListening()) after 6s of listening or so.
- Also make sure we force stopping at the end of the QA deadline.